### PR TITLE
Specify Activity to be Badged

### DIFF
--- a/ShortcutBadger/build.gradle
+++ b/ShortcutBadger/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
 
-    compileSdkVersion 19
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 21
         versionCode 1
         versionName "1.0"
     }
@@ -15,4 +15,3 @@ android {
 
 }
 
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AdwHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AdwHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
@@ -17,8 +18,8 @@ public class AdwHomeBadger extends ShortcutBadger {
     public static final String PACKAGENAME = "PNAME";
     public static final String COUNT = "COUNT";
 
-    public AdwHomeBadger(Context context) {
-        super(context);
+    public AdwHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/Android2HomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/Android2HomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
@@ -17,8 +18,8 @@ import java.util.List;
 public class Android2HomeBadger extends ShortcutBadger {
     private static final String CONTENT_URI = "content://com.android.launcher2.settings/favorites?notify=true";
 
-    public Android2HomeBadger(Context context) {
-        super(context);
+    public Android2HomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AndroidHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AndroidHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
@@ -17,8 +18,8 @@ import java.util.List;
 public class AndroidHomeBadger extends ShortcutBadger {
     private static final String CONTENT_URI = "content://com.android.launcher2.settings/favorites?notify=true";
 
-    public AndroidHomeBadger(Context context) {
-        super(context);
+    public AndroidHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/ApexHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/ApexHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
@@ -19,8 +20,8 @@ public class ApexHomeBadger extends ShortcutBadger {
     private static final String COUNT = "count";
     private static final String CLASS = "class";
 
-    public ApexHomeBadger(Context context) {
-        super(context);
+    public ApexHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeLauncher.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeLauncher.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
@@ -18,8 +19,8 @@ public class AsusHomeLauncher extends ShortcutBadger {
     private static final String INTENT_EXTRA_PACKAGENAME = "badge_count_package_name";
     private static final String INTENT_EXTRA_ACTIVITY_NAME = "badge_count_class_name";
 
-    public AsusHomeLauncher(Context context) {
-        super(context);
+    public AsusHomeLauncher(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import me.leolin.shortcutbadger.ShortcutBadger;
@@ -17,8 +18,8 @@ public class LGHomeBadger extends ShortcutBadger {
     private static final String INTENT_EXTRA_PACKAGENAME = "badge_count_package_name";
     private static final String INTENT_EXTRA_ACTIVITY_NAME = "badge_count_class_name";
 
-    public LGHomeBadger(Context context) {
-        super(context);
+    public LGHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NewHtcHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NewHtcHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -21,8 +22,8 @@ public class NewHtcHomeBadger extends ShortcutBadger {
     public static final String EXTRA_COMPONENT = "com.htc.launcher.extra.COMPONENT";
     public static final String EXTRA_COUNT = "com.htc.launcher.extra.COUNT";
 
-    public NewHtcHomeBadger(Context context) {
-        super(context);
+    public NewHtcHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NovaHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NovaHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
@@ -22,8 +23,8 @@ public class NovaHomeBadger extends ShortcutBadger {
     private static final String COUNT = "count";
     private static final String TAG = "tag";
 
-    public NovaHomeBadger(final Context context) {
-        super(context);
+    public NovaHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SamsungHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SamsungHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
@@ -19,8 +20,8 @@ public class SamsungHomeBadger extends ShortcutBadger {
     private static final String CONTENT_URI = "content://com.sec.badge/apps?notify=true";
     private static final String[] CONTENT_PROJECTION = new String[]{"_id","class"};
 
-    public SamsungHomeBadger(Context context) {
-        super(context);
+    public SamsungHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SolidHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SolidHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
@@ -19,8 +20,8 @@ public class SolidHomeBadger extends ShortcutBadger {
     private static final String COUNT = "com.majeur.launcher.intent.extra.BADGE_COUNT";
     private static final String CLASS = "com.majeur.launcher.intent.extra.BADGE_CLASS";
 
-    public SolidHomeBadger(Context context) {
-        super(context);
+    public SolidHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SonyHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SonyHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import me.leolin.shortcutbadger.ShortcutBadger;
@@ -19,8 +20,8 @@ public class SonyHomeBadger extends ShortcutBadger {
     private static final String INTENT_EXTRA_SHOW_MESSAGE = "com.sonyericsson.home.intent.extra.badge.SHOW_MESSAGE";
 
 
-    public SonyHomeBadger(Context context) {
-        super(context);
+    public SonyHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
@@ -1,5 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
@@ -18,8 +19,8 @@ public class XiaomiHomeBadger extends ShortcutBadger {
     public static final String EXTRA_UPDATE_APP_COMPONENT_NAME = "android.intent.extra.update_application_component_name";
     public static final String EXTRA_UPDATE_APP_MSG_TEXT = "android.intent.extra.update_application_message_text";
 
-    public XiaomiHomeBadger(Context context) {
-        super(context);
+    public XiaomiHomeBadger(Context context, Class<? extends Activity> activityToBadge) {
+        super(context, activityToBadge);
     }
 
     @Override


### PR DESCRIPTION
Added ability to specify activity to be badged instead of always selecting the default one. Useful for apps with multiple launcher activities.