### PR TITLE
We need to know if executeBadge actually works or not

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AdwHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AdwHomeBadger.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +27,11 @@ public class AdwHomeBadger implements Badger {
         Intent intent = new Intent(INTENT_UPDATE_COUNTER);
         intent.putExtra(PACKAGENAME, componentName.getPackageName());
         intent.putExtra(COUNT, badgeCount);
-        context.sendBroadcast(intent);
+        if(BroadcastHelper.canResolveBroadcast(context, intent)) {
+            context.sendBroadcast(intent);
+        } else {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/ApexHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/ApexHomeBadger.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +29,11 @@ public class ApexHomeBadger implements Badger {
         intent.putExtra(PACKAGENAME, componentName.getPackageName());
         intent.putExtra(COUNT, badgeCount);
         intent.putExtra(CLASS, componentName.getClassName());
-        context.sendBroadcast(intent);
+        if(BroadcastHelper.canResolveBroadcast(context, intent)) {
+            context.sendBroadcast(intent);
+        } else {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeLauncher.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeLauncher.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +29,11 @@ public class AsusHomeLauncher implements Badger {
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
         intent.putExtra("badge_vip_count", 0);
-        context.sendBroadcast(intent);
+        if(BroadcastHelper.canResolveBroadcast(context, intent)) {
+            context.sendBroadcast(intent);
+        } else {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +27,11 @@ public class DefaultBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
-        context.sendBroadcast(intent);
+        if(BroadcastHelper.canResolveBroadcast(context, intent)) {
+            context.sendBroadcast(intent);
+        } else {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +30,11 @@ public class LGHomeBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
-        context.sendBroadcast(intent);
+        if(BroadcastHelper.canResolveBroadcast(context, intent)) {
+            context.sendBroadcast(intent);
+        } else {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NewHtcHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NewHtcHomeBadger.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,12 +30,17 @@ public class NewHtcHomeBadger implements Badger {
         Intent intent1 = new Intent(INTENT_SET_NOTIFICATION);
         intent1.putExtra(EXTRA_COMPONENT, componentName.flattenToShortString());
         intent1.putExtra(EXTRA_COUNT, badgeCount);
-        context.sendBroadcast(intent1);
 
         Intent intent = new Intent(INTENT_UPDATE_SHORTCUT);
         intent.putExtra(PACKAGENAME, componentName.getPackageName());
         intent.putExtra(COUNT, badgeCount);
-        context.sendBroadcast(intent);
+
+        if(BroadcastHelper.canResolveBroadcast(context, intent1) || BroadcastHelper.canResolveBroadcast(context, intent)) {
+            context.sendBroadcast(intent1);
+            context.sendBroadcast(intent);
+        } else {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NovaHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NovaHomeBadger.java
@@ -27,20 +27,11 @@ public class NovaHomeBadger implements Badger {
 
     @Override
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
-        try {
-            ContentValues contentValues = new ContentValues();
-            contentValues.put(TAG, componentName.getPackageName() + "/" + componentName.getClassName());
-            contentValues.put(COUNT, badgeCount);
-            context.getContentResolver().insert(Uri.parse(CONTENT_URI), contentValues);
-        } catch (IllegalArgumentException ex) {
-            /* Fine, TeslaUnread is not installed. */
-        } catch (Exception ex) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(TAG, componentName.getPackageName() + "/" + componentName.getClassName());
+        contentValues.put(COUNT, badgeCount);
+        context.getContentResolver().insert(Uri.parse(CONTENT_URI), contentValues);
 
-            /* Some other error, possibly because the format
-            of the ContentValues are incorrect. */
-
-            throw new ShortcutBadgeException(ex.getMessage());
-        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SolidHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SolidHomeBadger.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,7 +28,11 @@ public class SolidHomeBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_COUNT, badgeCount);
         intent.putExtra(INTENT_EXTRA_CLASS, componentName.getClassName());
-        context.sendBroadcast(intent);
+        if(BroadcastHelper.canResolveBroadcast(context, intent)) {
+            context.sendBroadcast(intent);
+        } else {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -34,7 +35,11 @@ public class XiaomiHomeBadger implements Badger {
                     INTENT_ACTION);
             localIntent.putExtra(EXTRA_UPDATE_APP_COMPONENT_NAME, componentName.getPackageName() + "/" + componentName.getClassName());
             localIntent.putExtra(EXTRA_UPDATE_APP_MSG_TEXT, String.valueOf(badgeCount == 0 ? "" : badgeCount));
-            context.sendBroadcast(localIntent);
+            if(BroadcastHelper.canResolveBroadcast(context, localIntent)) {
+                context.sendBroadcast(localIntent);
+            } else {
+                throw new ShortcutBadgeException("unable to resolve intent: " + localIntent.toString());
+            }
         }
     }
 

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
@@ -1,0 +1,19 @@
+package me.leolin.shortcutbadger.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+
+import java.util.List;
+
+/**
+ * Created by mahijazi on 17/05/16.
+ */
+public class BroadcastHelper {
+	public static boolean canResolveBroadcast(Context context, Intent intent) {
+		PackageManager packageManager = context.getPackageManager();
+		List<ResolveInfo> receivers = packageManager.queryBroadcastReceivers(intent, 0);
+		return receivers != null && receivers.size() > 0;
+	}
+}


### PR DESCRIPTION
Our app needs to know if the library was able to put the
unread badge or not, applyCount should return true only
when it was able to put the badge and this is not the case now.

Right now most badgers sendBroadcast which will never throw any
exception if there are no receivers to handle the broadcast.
So I wrapped all sendBroadcast calls with a check and throw an
exception if there is no receiver that can handle this intent.

NovaHomeBadger was alsow hiding the failure if TeslaUnread is
not installed which is not correct.