### PR TITLE
Return Samsung badger

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -34,7 +34,7 @@ public final class ShortcutBadger {
         BADGERS.add(AsusHomeLauncher.class);
         BADGERS.add(HuaweiHomeBadger.class);
 //        BADGERS.add(LGHomeBadger.class);
-//        BADGERS.add(SamsungHomeBadger.class);
+        BADGERS.add(SamsungHomeBadger.class);
     }
 
     private static Badger sShortcutBadger;


### PR DESCRIPTION
Return Samsung badger. Default badger doesn't work on Samsung GT-N7100, Android 4.4.2