### PR TITLE
Disable log in "applyCount"

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -64,7 +64,9 @@ public final class ShortcutBadger {
             applyCountOrThrow(context, badgeCount);
             return true;
         } catch (ShortcutBadgeException e) {
-            Log.e(LOG_TAG, "Unable to execute badge", e);
+            if (Log.isLoggable(LOG_TAG, Log.ERROR)) {
+                Log.e(LOG_TAG, "Unable to execute badge", e);
+            }
             return false;
         }
     }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -64,8 +64,8 @@ public final class ShortcutBadger {
             applyCountOrThrow(context, badgeCount);
             return true;
         } catch (ShortcutBadgeException e) {
-            if (Log.isLoggable(LOG_TAG, Log.ERROR)) {
-                Log.e(LOG_TAG, "Unable to execute badge", e);
+            if (Log.isLoggable(LOG_TAG, Log.DEBUG)) {
+                Log.d(LOG_TAG, "Unable to execute badge", e);
             }
             return false;
         }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/HuaweiHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/HuaweiHomeBadger.java
@@ -4,7 +4,6 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,20 +16,11 @@ import me.leolin.shortcutbadger.ShortcutBadgeException;
  */
 public class HuaweiHomeBadger implements Badger {
 
-    private static final String LOG_TAG = HuaweiHomeBadger.class.getSimpleName();
-
     @Override
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
-        String launcherClassName = componentName.getClassName();
-        if (launcherClassName == null) {
-            if (Log.isLoggable(LOG_TAG, Log.DEBUG)) {
-                Log.d(LOG_TAG, "Main activity is null");
-            }
-            return;
-        }
         Bundle localBundle = new Bundle();
         localBundle.putString("package", context.getPackageName());
-        localBundle.putString("class", launcherClassName);
+        localBundle.putString("class", componentName.getClassName());
         localBundle.putInt("badgenumber", badgeCount);
         context.getContentResolver().call(Uri.parse("content://com.huawei.android.launcher.settings/badge/"), "change_badge", null, localBundle);
     }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/HuaweiHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/HuaweiHomeBadger.java
@@ -23,7 +23,9 @@ public class HuaweiHomeBadger implements Badger {
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
         String launcherClassName = componentName.getClassName();
         if (launcherClassName == null) {
-            Log.d(LOG_TAG, "Main activity is null");
+            if (Log.isLoggable(LOG_TAG, Log.DEBUG)) {
+                Log.d(LOG_TAG, "Main activity is null");
+            }
             return;
         }
         Bundle localBundle = new Bundle();


### PR DESCRIPTION
ApplyCount catch the exception and logs it into logcat.
It's pretty annoying, since library don't provide way to check if device supports badge. So you have to call this method anyway. And each time it prints exception in log, even if you expect that device do not support badges.

Actually I'm not sure when this log is useful, since if you need the exception you can call `applyCountOrThrow`.

But anyway, this PR makes this log optional. If someone need this log, it can be enabled using adb:
`adb shell setprop log.tag.ShortcutBadger DEBUG`

Also I removed another log from `HuaweiHomeBadger`, since it should never happen and all other impls don't check for null.

@leolin310148 PTAL
