### PR TITLE
Badgers implementations should only query the current/default launcher

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class BroadcastHelper {
 	public static boolean canResolveBroadcast(Context context, Intent intent) {
 		PackageManager packageManager = context.getPackageManager();
-		List<ResolveInfo> receivers = packageManager.queryBroadcastReceivers(intent, 0);
+		List<ResolveInfo> receivers = packageManager.queryBroadcastReceivers(intent, PackageManager.MATCH_DEFAULT_ONLY);
 		return receivers != null && receivers.size() > 0;
 	}
 }


### PR DESCRIPTION
If you have multiple launchers installed then the current `isBadgeCounterSupported()` method always returns true. Even if you have as current (default) launcher one that isn't supported. 
For example if you use a Samsung device (which by default supports ShortcutBadger) and then install as well as set the Google Now launcher as default.

The root cause seems that in this case `initBadger()` returns always a DefaultBadger. And DefaultBadger executes an broadcast to every launcher via `packageManager.queryBroadcastReceivers(intent, 0)`.
If you change the flag from 0 to `PackageManager.MATCH_DEFAULT_ONLY)` the check is then only against the current/default launcher.