### PR TITLE
Updated code to get home-package resolver to support more launchers

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -199,22 +199,21 @@ public final class ShortcutBadger {
 
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_HOME);
-        ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY);
+        List<ResolveInfo> resolveInfos = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
 
-        if (resolveInfo == null || resolveInfo.activityInfo.name.toLowerCase().contains("resolver"))
-            return false;
+        for (ResolveInfo resolveInfo : resolveInfos) {
+            String currentHomePackage = resolveInfo.activityInfo.packageName;
 
-        String currentHomePackage = resolveInfo.activityInfo.packageName;
-
-        for (Class<? extends Badger> badger : BADGERS) {
-            Badger shortcutBadger = null;
-            try {
-                shortcutBadger = badger.newInstance();
-            } catch (Exception ignored) {
-            }
-            if (shortcutBadger != null && shortcutBadger.getSupportLaunchers().contains(currentHomePackage)) {
-                sShortcutBadger = shortcutBadger;
-                break;
+            for (Class<? extends Badger> badger : BADGERS) {
+                Badger shortcutBadger = null;
+                try {
+                    shortcutBadger = badger.newInstance();
+                } catch (Exception ignored) {
+                }
+                if (shortcutBadger != null && shortcutBadger.getSupportLaunchers().contains(currentHomePackage)) {
+                    sShortcutBadger = shortcutBadger;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Issue:
The current way of getting resolveActivity returns just 1 homepackage which may or may not be supported.
Fix:
Using queryIntentActivities, we will get all the supported homepackages, and if any of them matches to supported launchers, we will use that as shortcutBadger. This way we are supposed to get more supported devices for the library.