### PR TITLE
use the first match among resolveInfos

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -215,6 +215,9 @@ public final class ShortcutBadger {
                     break;
                 }
             }
+            if (sShortcutBadger != null) {
+                break;
+            }
         }
 
         if (sShortcutBadger == null) {

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
@@ -4,8 +4,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import me.leolin.shortcutbadger.Badger;


### PR DESCRIPTION
Current source uses the last matched badger, but `PackageManager#queryIntentActivities` returns List of ResolveInfo sorted from best to worst.

This pull request uses the first matching badger, which is better.