### PR TITLE
 Make sure isBadgeCounterSupported returns false on Samsung on Android 8+

### DIFF
--- a/SampleApp/src/main/java/me/leolin/shortcutbadger/example/MainActivity.java
+++ b/SampleApp/src/main/java/me/leolin/shortcutbadger/example/MainActivity.java
@@ -69,6 +69,16 @@ public class MainActivity extends Activity {
             }
         });
 
+        Button isBadgeSupportedBtn = (Button) findViewById(R.id.btnIsBadgeSupported);
+        isBadgeSupportedBtn.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                boolean success = ShortcutBadger.isBadgeCounterSupported(MainActivity.this);
+
+                Toast.makeText(getApplicationContext(), "isBadgeCounterSupported=" + success, Toast.LENGTH_SHORT).show();
+            }
+        });
+
 
         //find the home launcher Package
         Intent intent = new Intent(Intent.ACTION_MAIN);

--- a/SampleApp/src/main/res/layout/activity_main.xml
+++ b/SampleApp/src/main/res/layout/activity_main.xml
@@ -46,5 +46,13 @@
         android:layout_centerVertical="true"
         android:text="Remove badge"/>
 
+    <Button
+        android:id="@+id/btnIsBadgeSupported"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:text="Is badge supported?"/>
+
 
 </LinearLayout>

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
@@ -3,6 +3,7 @@ package me.leolin.shortcutbadger.impl;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 
 import java.util.Arrays;
 import java.util.List;
@@ -22,6 +23,12 @@ public class DefaultBadger implements Badger {
 
     @Override
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
+        // The broadcast of "android.intent.action.BADGE_COUNT_UPDATE" is successfull on Samsung
+        // devices running Android 8, but it has no effect on badges. So we must check explicitly:
+        if (Build.MANUFACTURER.equalsIgnoreCase("Samsung") && Build.VERSION.SDK_INT >= 26) {
+            throw new ShortcutBadgeException("ShortcutBadger is not supported on Samsung devices running Android 8 (or newer)");
+        }
+
             Intent intent = new Intent(INTENT_ACTION);
             intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
             intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SamsungHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/SamsungHomeBadger.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import android.os.Build;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import me.leolin.shortcutbadger.Badger;
@@ -25,7 +26,8 @@ public class SamsungHomeBadger implements Badger {
     private DefaultBadger defaultBadger;
 
     public SamsungHomeBadger() {
-        if (Build.VERSION.SDK_INT >= 21) {
+        // Use default badger on Android 5.0 to Android 7.1, but not on Android 8 and newer:
+        if (Build.VERSION.SDK_INT >= 21 && Build.VERSION.SDK_INT < 26) {
             defaultBadger = new DefaultBadger();
         }
     }
@@ -77,9 +79,14 @@ public class SamsungHomeBadger implements Badger {
 
     @Override
     public List<String> getSupportLaunchers() {
-        return Arrays.asList(
-                "com.sec.android.app.launcher",
-                "com.sec.android.app.twlauncher"
-        );
+        if (Build.VERSION.SDK_INT >= 26) {
+            // Not supported on Android 8 (and newer)
+            return Collections.emptyList();
+        } else {
+            return Arrays.asList(
+                    "com.sec.android.app.launcher",
+                    "com.sec.android.app.twlauncher"
+            );
+        }
     }
 }


### PR DESCRIPTION
The fix is in `SamsungHomeBadger`, but: Note that the `DefaultBadger` also must check for Samsung on Android 8, or it will be used on those devices.

I have tried to do this fix without touching `DefaultBadger`, but it seems impossible with the current design of the API.

PS: The fix would still be technically valid only with the changes in `DefaultBadger` and not changing `SamsungHomeBadger` at all. However, I think the code changes in `SamsungHomeBadger` should be there anyway to better show that ShortcutBadger is not supported on Samsung devices running Android 8+.

This fixes #266

Also included:

* Update test app to be able to test isBadgeCounterSupported