### PR TITLE
Please allow non-manufacturer launchers to use DefaultBadger for all devices

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -221,16 +221,7 @@ public final class ShortcutBadger {
         }
 
         if (sShortcutBadger == null) {
-            if (Build.MANUFACTURER.equalsIgnoreCase("ZUK"))
-                sShortcutBadger = new ZukHomeBadger();
-            else if (Build.MANUFACTURER.equalsIgnoreCase("OPPO"))
-                sShortcutBadger = new OPPOHomeBader();
-            else if (Build.MANUFACTURER.equalsIgnoreCase("VIVO"))
-                sShortcutBadger = new VivoHomeBadger();
-            else if (Build.MANUFACTURER.equalsIgnoreCase("ZTE"))
-                sShortcutBadger = new ZTEHomeBadger();
-            else
-                sShortcutBadger = new DefaultBadger();
+            sShortcutBadger = new DefaultBadger();
         }
 
         return true;


### PR DESCRIPTION
Hi!

Sorry for my poor English!
Would you please change this section of code?
Otherwise launchers that not included to ShortcutBadger does not have possibility to use DefaultBadger on devices manufactured by "ZUK", "OPPO", "VIVO", "ZTE".

Thank you!