### PR TITLE
Oreo support improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ please use version 1.1.0+!
 
 CHANGE LOG
 ===================================
+1.1.20:
+
+* Renamed default broadcast action; added Android Oreo support.
 
 1.1.19:
 

--- a/SampleApp/build.gradle
+++ b/SampleApp/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "me.leolin.shortcutbadger.example"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -21,6 +21,6 @@ android {
 
 
 dependencies {
-//    compile 'me.leolin:ShortcutBadger:1.0.+@aar'
-    compile project(':ShortcutBadger')
+//    implementation 'me.leolin:ShortcutBadger:1.0.+@aar'
+    implementation project(':ShortcutBadger')
 }

--- a/SampleApp/src/main/java/me/leolin/shortcutbadger/example/BadgeIntentService.java
+++ b/SampleApp/src/main/java/me/leolin/shortcutbadger/example/BadgeIntentService.java
@@ -1,14 +1,19 @@
 package me.leolin.shortcutbadger.example;
 
+import android.annotation.TargetApi;
 import android.app.IntentService;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 
 import me.leolin.shortcutbadger.ShortcutBadger;
 
 public class BadgeIntentService extends IntentService {
+
+    private static final String NOTIFICATION_CHANNEL = "me.leolin.shortcutbadger.example";
 
     private int notificationId = 0;
 
@@ -36,9 +41,24 @@ public class BadgeIntentService extends IntentService {
                 .setContentTitle("")
                 .setContentText("")
                 .setSmallIcon(R.drawable.ic_launcher);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                setupNotificationChannel();
+
+                builder.setChannelId(NOTIFICATION_CHANNEL);
+            }
+
             Notification notification = builder.build();
             ShortcutBadger.applyNotification(getApplicationContext(), notification, badgeCount);
             mNotificationManager.notify(notificationId, notification);
         }
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private void setupNotificationChannel() {
+        NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL, "ShortcutBadger Sample",
+                NotificationManager.IMPORTANCE_DEFAULT);
+
+        mNotificationManager.createNotificationChannel(channel);
     }
 }

--- a/SampleApp/src/main/java/me/leolin/shortcutbadger/example/MainActivity.java
+++ b/SampleApp/src/main/java/me/leolin/shortcutbadger/example/MainActivity.java
@@ -22,9 +22,9 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        final EditText numInput = (EditText) findViewById(R.id.numInput);
+        final EditText numInput = findViewById(R.id.numInput);
 
-        Button button = (Button) findViewById(R.id.btnSetBadge);
+        Button button = findViewById(R.id.btnSetBadge);
         button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -41,7 +41,7 @@ public class MainActivity extends Activity {
             }
         });
 
-        Button launchNotification = (Button) findViewById(R.id.btnSetBadgeByNotification);
+        Button launchNotification = findViewById(R.id.btnSetBadgeByNotification);
         launchNotification.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -59,7 +59,7 @@ public class MainActivity extends Activity {
             }
         });
 
-        Button removeBadgeBtn = (Button) findViewById(R.id.btnRemoveBadge);
+        Button removeBadgeBtn = findViewById(R.id.btnRemoveBadge);
         removeBadgeBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -76,7 +76,7 @@ public class MainActivity extends Activity {
         ResolveInfo resolveInfo = getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY);
         String currentHomePackage = resolveInfo.activityInfo.packageName;
 
-        TextView textViewHomePackage = (TextView) findViewById(R.id.textViewHomePackage);
+        TextView textViewHomePackage = findViewById(R.id.textViewHomePackage);
         textViewHomePackage.setText("launcher:" + currentHomePackage);
     }
 

--- a/ShortcutBadger/build.gradle
+++ b/ShortcutBadger/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
 
-    compileSdkVersion 19
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 19
+        minSdkVersion 14
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         consumerProguardFiles 'proguard-rules.pro'

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AdwHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AdwHomeBadger.java
@@ -23,16 +23,12 @@ public class AdwHomeBadger implements Badger {
 
     @Override
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
-
         Intent intent = new Intent(INTENT_UPDATE_COUNTER);
         intent.putExtra(PACKAGENAME, componentName.getPackageName());
         intent.putExtra(CLASSNAME, componentName.getClassName());
         intent.putExtra(COUNT, badgeCount);
-        if (BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent);
-        } else {
-            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
-        }
+
+        BroadcastHelper.sendIntentExplicitly(context, intent);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/ApexHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/ApexHomeBadger.java
@@ -23,16 +23,12 @@ public class ApexHomeBadger implements Badger {
 
     @Override
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
-
         Intent intent = new Intent(INTENT_UPDATE_COUNTER);
         intent.putExtra(PACKAGENAME, componentName.getPackageName());
         intent.putExtra(COUNT, badgeCount);
         intent.putExtra(CLASS, componentName.getClassName());
-        if (BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent);
-        } else {
-            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
-        }
+
+        BroadcastHelper.sendIntentExplicitly(context, intent);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeBadger.java
@@ -29,7 +29,7 @@ public class AsusHomeBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
         intent.putExtra("badge_vip_count", 0);
 
-        BroadcastHelper.sendIntentExplicitly(context, intent);
+        BroadcastHelper.sendDefaultIntentExplicitly(context, intent);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/AsusHomeBadger.java
@@ -16,7 +16,7 @@ import me.leolin.shortcutbadger.util.BroadcastHelper;
  */
 public class AsusHomeBadger implements Badger {
 
-    private static final String INTENT_ACTION = "android.intent.action.BADGE_COUNT_UPDATE";
+    private static final String INTENT_ACTION = IntentConstants.DEFAULT_INTENT_ACTION;
     private static final String INTENT_EXTRA_BADGE_COUNT = "badge_count";
     private static final String INTENT_EXTRA_PACKAGENAME = "badge_count_package_name";
     private static final String INTENT_EXTRA_ACTIVITY_NAME = "badge_count_class_name";
@@ -28,11 +28,8 @@ public class AsusHomeBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
         intent.putExtra("badge_vip_count", 0);
-        if (BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent);
-        } else {
-            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
-        }
+
+        BroadcastHelper.sendIntentExplicitly(context, intent);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
@@ -15,22 +15,19 @@ import me.leolin.shortcutbadger.util.BroadcastHelper;
  * @author leolin
  */
 public class DefaultBadger implements Badger {
-    private static final String INTENT_ACTION = "android.intent.action.BADGE_COUNT_UPDATE";
+    private static final String INTENT_ACTION = IntentConstants.DEFAULT_INTENT_ACTION;
     private static final String INTENT_EXTRA_BADGE_COUNT = "badge_count";
     private static final String INTENT_EXTRA_PACKAGENAME = "badge_count_package_name";
     private static final String INTENT_EXTRA_ACTIVITY_NAME = "badge_count_class_name";
 
     @Override
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
-            Intent intent = new Intent(INTENT_ACTION);
-            intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
-            intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
-            intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
-        if (BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent);
-        } else {
-            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
-        }
+        Intent intent = new Intent(INTENT_ACTION);
+        intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
+        intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
+        intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
+
+        BroadcastHelper.sendIntentExplicitly(context, intent);
     }
 
     @Override
@@ -44,6 +41,6 @@ public class DefaultBadger implements Badger {
 
     boolean isSupported(Context context) {
         Intent intent = new Intent(INTENT_ACTION);
-        return BroadcastHelper.canResolveBroadcast(context, intent);
+        return BroadcastHelper.resolveBroadcast(context, intent).size() > 0;
     }
 }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/DefaultBadger.java
@@ -3,6 +3,7 @@ package me.leolin.shortcutbadger.impl;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,7 +28,7 @@ public class DefaultBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
 
-        BroadcastHelper.sendIntentExplicitly(context, intent);
+        BroadcastHelper.sendDefaultIntentExplicitly(context, intent);
     }
 
     @Override
@@ -41,6 +42,8 @@ public class DefaultBadger implements Badger {
 
     boolean isSupported(Context context) {
         Intent intent = new Intent(INTENT_ACTION);
-        return BroadcastHelper.resolveBroadcast(context, intent).size() > 0;
+        return BroadcastHelper.resolveBroadcast(context, intent).size() > 0
+                || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                    && BroadcastHelper.resolveBroadcast(context, new Intent(IntentConstants.DEFAULT_OREO_INTENT_ACTION)).size() > 0);
     }
 }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/IntentConstants.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/IntentConstants.java
@@ -1,10 +1,6 @@
 package me.leolin.shortcutbadger.impl;
 
-import android.os.Build;
-
-interface IntentConstants {
-
-    String DEFAULT_INTENT_ACTION = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
-            ? "me.leolin.shortcutbadger.BADGE_COUNT_UPDATE"
-            : "android.intent.action.BADGE_COUNT_UPDATE";
+public interface IntentConstants {
+    String DEFAULT_INTENT_ACTION = "android.intent.action.BADGE_COUNT_UPDATE";
+    String DEFAULT_OREO_INTENT_ACTION = "me.leolin.shortcutbadger.BADGE_COUNT_UPDATE";
 }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/IntentConstants.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/IntentConstants.java
@@ -1,0 +1,10 @@
+package me.leolin.shortcutbadger.impl;
+
+import android.os.Build;
+
+interface IntentConstants {
+
+    String DEFAULT_INTENT_ACTION = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+            ? "me.leolin.shortcutbadger.BADGE_COUNT_UPDATE"
+            : "android.intent.action.BADGE_COUNT_UPDATE";
+}

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
@@ -4,13 +4,12 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 
-import me.leolin.shortcutbadger.Badger;
-import me.leolin.shortcutbadger.ShortcutBadgeException;
-import me.leolin.shortcutbadger.ShortcutBadger;
-import me.leolin.shortcutbadger.util.BroadcastHelper;
-
 import java.util.Arrays;
 import java.util.List;
+
+import me.leolin.shortcutbadger.Badger;
+import me.leolin.shortcutbadger.ShortcutBadgeException;
+import me.leolin.shortcutbadger.util.BroadcastHelper;
 
 /**
  * @author Leo Lin
@@ -31,7 +30,7 @@ public class LGHomeBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
 
-        BroadcastHelper.sendIntentExplicitly(context, intent);
+        BroadcastHelper.sendDefaultIntentExplicitly(context, intent);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/LGHomeBadger.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Deprecated
 public class LGHomeBadger implements Badger {
 
-    private static final String INTENT_ACTION = "android.intent.action.BADGE_COUNT_UPDATE";
+    private static final String INTENT_ACTION = IntentConstants.DEFAULT_INTENT_ACTION;
     private static final String INTENT_EXTRA_BADGE_COUNT = "badge_count";
     private static final String INTENT_EXTRA_PACKAGENAME = "badge_count_package_name";
     private static final String INTENT_EXTRA_ACTIVITY_NAME = "badge_count_class_name";
@@ -30,11 +30,8 @@ public class LGHomeBadger implements Badger {
         intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_ACTIVITY_NAME, componentName.getClassName());
-        if(BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent);
-        } else {
-            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
-        }
+
+        BroadcastHelper.sendIntentExplicitly(context, intent);
     }
 
     @Override

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NewHtcHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/NewHtcHomeBadger.java
@@ -4,13 +4,12 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 
+import java.util.Collections;
+import java.util.List;
+
 import me.leolin.shortcutbadger.Badger;
 import me.leolin.shortcutbadger.ShortcutBadgeException;
-import me.leolin.shortcutbadger.ShortcutBadger;
 import me.leolin.shortcutbadger.util.BroadcastHelper;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * @author Leo Lin
@@ -28,23 +27,38 @@ public class NewHtcHomeBadger implements Badger {
     public void executeBadge(Context context, ComponentName componentName, int badgeCount) throws ShortcutBadgeException {
 
         Intent intent1 = new Intent(INTENT_SET_NOTIFICATION);
+        boolean intent1Success;
+
         intent1.putExtra(EXTRA_COMPONENT, componentName.flattenToShortString());
         intent1.putExtra(EXTRA_COUNT, badgeCount);
 
         Intent intent = new Intent(INTENT_UPDATE_SHORTCUT);
+        boolean intentSuccess;
+
         intent.putExtra(PACKAGENAME, componentName.getPackageName());
         intent.putExtra(COUNT, badgeCount);
 
-        if(BroadcastHelper.canResolveBroadcast(context, intent1) || BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent1);
-            context.sendBroadcast(intent);
-        } else {
+        try {
+            BroadcastHelper.sendIntentExplicitly(context, intent1);
+            intent1Success = true;
+        } catch (ShortcutBadgeException e) {
+            intent1Success = false;
+        }
+
+        try {
+            BroadcastHelper.sendIntentExplicitly(context, intent);
+            intentSuccess = true;
+        } catch (ShortcutBadgeException e) {
+            intentSuccess = false;
+        }
+
+        if (!intent1Success && !intentSuccess) {
             throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
         }
     }
 
     @Override
     public List<String> getSupportLaunchers() {
-        return Arrays.asList("com.htc.launcher");
+        return Collections.singletonList("com.htc.launcher");
     }
 }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/OPPOHomeBader.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/OPPOHomeBader.java
@@ -59,11 +59,8 @@ public class OPPOHomeBader implements Badger {
         intent.putExtra(INTENT_EXTRA_PACKAGENAME, componentName.getPackageName());
         intent.putExtra(INTENT_EXTRA_BADGE_COUNT, badgeCount);
         intent.putExtra(INTENT_EXTRA_BADGE_UPGRADENUMBER, badgeCount);
-        if (BroadcastHelper.canResolveBroadcast(context, intent)) {
-            context.sendBroadcast(intent);
-        } else {
-            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
-        }
+
+        BroadcastHelper.sendIntentExplicitly(context, intent);
     }
 
     /**

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/XiaomiHomeBadger.java
@@ -48,9 +48,10 @@ public class XiaomiHomeBadger implements Badger {
                     INTENT_ACTION);
             localIntent.putExtra(EXTRA_UPDATE_APP_COMPONENT_NAME, componentName.getPackageName() + "/" + componentName.getClassName());
             localIntent.putExtra(EXTRA_UPDATE_APP_MSG_TEXT, String.valueOf(badgeCount == 0 ? "" : badgeCount));
-            if (BroadcastHelper.canResolveBroadcast(context, localIntent)) {
-                context.sendBroadcast(localIntent);
-            }
+
+            try {
+                BroadcastHelper.sendIntentExplicitly(context, localIntent);
+            } catch (ShortcutBadgeException ignored) {}
         }
         if (Build.MANUFACTURER.equalsIgnoreCase("Xiaomi")) {
             tryNewMiuiBadge(context, badgeCount);

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
@@ -4,11 +4,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.os.Build;
 
 import java.util.Collections;
 import java.util.List;
 
 import me.leolin.shortcutbadger.ShortcutBadgeException;
+import me.leolin.shortcutbadger.impl.IntentConstants;
 
 /**
  * Created by mahijazi on 17/05/16.
@@ -37,5 +39,29 @@ public class BroadcastHelper {
                 context.sendBroadcast(actualIntent);
             }
         }
+    }
+
+    public static void sendDefaultIntentExplicitly(Context context, Intent intent) throws ShortcutBadgeException {
+        boolean oreoIntentSuccess = false;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Intent oreoIntent = new Intent(intent);
+
+            oreoIntent.setAction(IntentConstants.DEFAULT_OREO_INTENT_ACTION);
+
+            try {
+                sendIntentExplicitly(context, oreoIntent);
+                oreoIntentSuccess = true;
+            } catch (ShortcutBadgeException e) {
+                oreoIntentSuccess = false;
+            }
+        }
+
+        if (oreoIntentSuccess) {
+            return;
+        }
+
+        // try pre-Oreo default intent
+        sendIntentExplicitly(context, intent);
     }
 }

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
@@ -5,15 +5,37 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 
+import java.util.Collections;
 import java.util.List;
+
+import me.leolin.shortcutbadger.ShortcutBadgeException;
 
 /**
  * Created by mahijazi on 17/05/16.
  */
 public class BroadcastHelper {
-	public static boolean canResolveBroadcast(Context context, Intent intent) {
-		PackageManager packageManager = context.getPackageManager();
-		List<ResolveInfo> receivers = packageManager.queryBroadcastReceivers(intent, 0);
-		return receivers != null && receivers.size() > 0;
-	}
+
+    public static List<ResolveInfo> resolveBroadcast(Context context, Intent intent) {
+        PackageManager packageManager = context.getPackageManager();
+        List<ResolveInfo> receivers = packageManager.queryBroadcastReceivers(intent, 0);
+
+        return receivers != null ? receivers : Collections.<ResolveInfo>emptyList();
+    }
+
+    public static void sendIntentExplicitly(Context context, Intent intent) throws ShortcutBadgeException {
+        List<ResolveInfo> resolveInfos = resolveBroadcast(context, intent);
+
+        if (resolveInfos.size() == 0) {
+            throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
+        }
+
+        for (ResolveInfo info : resolveInfos) {
+            Intent actualIntent = new Intent(intent);
+
+            if (info != null) {
+                actualIntent.setPackage(info.resolvePackageName);
+                context.sendBroadcast(actualIntent);
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
     ext {
         POM_NAME = 'ShortcutBadger'
@@ -32,9 +33,11 @@ subprojects {
         repositories {
             jcenter()
             mavenCentral()
+            google()
+            google()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:2.3.1'
+            classpath 'com.android.tools.build:gradle:3.1.0'
         }
     }
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Mar 19 01:12:37 CST 2017
+#Sun Apr 01 16:48:39 MSK 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip


### PR DESCRIPTION
#274 should be possible to fix, but launchers will need to update intent for Oreo

New intent action added and broadcasts sending were made explicit (only to resolved packages).
If oreo-specific intent sending failed, then default intent will be used.

Also, Sample app fixed to use modern notification APIs.