### PR TITLE
Changed compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ USAGE
 <br/>2. Add dependencies for ShortcutBadger, it's available from maven now.
         
         dependencies {
-            compile "me.leolin:ShortcutBadger:1.1.22@aar"
+            implementation "me.leolin:ShortcutBadger:1.1.22@aar"
         }
 
 <br/>3. Add the codes below:


### PR DESCRIPTION
To remove message configuration `compile` is obsolete and has been replaced with `implementation` and 'api'. It will be removed at the end of 2018.