### PR TITLE
add honor launcher package name.

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -262,6 +262,9 @@ public final class ShortcutBadger {
      * @param resolveInfos          list of all Home activities in the system
      */
     private static void validateInfoList(ResolveInfo defaultActivity, List<ResolveInfo> resolveInfos) {
+        if (resolveInfos == null || resolveInfos.isEmpty()) {
+            return;
+        }
         int indexToSwapWith = 0;
         for (int i = 0, resolveInfosSize = resolveInfos.size(); i < resolveInfosSize; i++) {
             ResolveInfo resolveInfo = resolveInfos.get(i);

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/ShortcutBadger.java
@@ -265,15 +265,28 @@ public final class ShortcutBadger {
         if (resolveInfos == null || resolveInfos.isEmpty()) {
             return;
         }
+        if (!hasPackageName(defaultActivity)) {
+            return;
+        }
         int indexToSwapWith = 0;
         for (int i = 0, resolveInfosSize = resolveInfos.size(); i < resolveInfosSize; i++) {
             ResolveInfo resolveInfo = resolveInfos.get(i);
+            if (!hasPackageName(resolveInfo)) {
+                continue;
+            }
             String currentActivityName = resolveInfo.activityInfo.packageName;
             if (currentActivityName.equals(defaultActivity.activityInfo.packageName)) {
                 indexToSwapWith = i;
             }
         }
         Collections.swap(resolveInfos, 0, indexToSwapWith);
+    }
+
+    private static boolean hasPackageName(ResolveInfo resolveInfo) {
+        if (resolveInfo == null || resolveInfo.activityInfo == null) {
+            return false;
+        }
+        return resolveInfo.activityInfo.packageName != null;
     }
 
     // Avoid anybody to instantiate this class

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/HuaweiHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/HuaweiHomeBadger.java
@@ -28,7 +28,8 @@ public class HuaweiHomeBadger implements Badger {
     @Override
     public List<String> getSupportLaunchers() {
         return Arrays.asList(
-                "com.huawei.android.launcher"
+                "com.huawei.android.launcher",
+                "com.hihonor.android.launcher"
         );
     }
 }


### PR DESCRIPTION
got a email form hihonor.com: 

```
主　题：【高优先级】关于荣耀手机参数修改的适配沟通
 
 
您好！
新荣耀手机修改了一些手机的属性值和APK包名。
 
当前已知对三方应用的角标和指纹功能产生了一些影响，需要应用协助重点排查这两个功能。非常感谢！  
 

可能出现的问题现象：
现象1： 应用数字角标和原点角标，来消息（包括Push消息）后，不显示更新角标； 
现象2： 应用数字角标和原点角标，在查看消息后，角标不更新；
现象3： 应用指纹相关功能失效或者指纹设置入口找不到（如应用本身无指纹相关功能，则无需关注）；
 
当前已排查出问题的可能原因： 
1. 三方应用采用build.manufacture来特殊处理角标或者指纹相关功能( build.manufacture由HUAWEI修改为HONOR)；
2. 三方应用判断launcher名字来做特殊处理，导致角标功能失效(com.huawei.android.launcher 修改为com.hihonor.android.launcher)； 
以上影响仅限于即将发布的新荣耀手机以及以后的所有荣耀手机，已经上市发布的荣耀手机不受影响。
 
 
基于以上背景，烦请应用方安排相应排查，附件为适配文档供参考。
```