### PR TITLE
Fix failing to send broadcast intent on Android 8+

### DIFF
--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/util/BroadcastHelper.java
@@ -2,6 +2,7 @@ package me.leolin.shortcutbadger.util;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
@@ -31,12 +32,15 @@ public class BroadcastHelper {
             throw new ShortcutBadgeException("unable to resolve intent: " + intent.toString());
         }
 
-        for (ResolveInfo info : resolveInfos) {
+        for (ResolveInfo resolveInfo : resolveInfos) {
             Intent actualIntent = new Intent(intent);
 
-            if (info != null) {
-                actualIntent.setPackage(info.resolvePackageName);
-                context.sendBroadcast(actualIntent);
+            if (resolveInfo != null) {
+                ActivityInfo activityInfo = resolveInfo.activityInfo;
+                if (activityInfo != null) {
+                    actualIntent.setPackage(activityInfo.packageName);
+                    context.sendBroadcast(actualIntent);
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes that some Badger classes (include DefaultBadger) failing to broadcast Intent on Android 8+ devices.
The cause of this issue is that `BroadcastHelper.sendIntentExplicitly()` broadcasts implicit intents instead of explicit intents.

The original code uses `ResolveInfo#resolvePackageName` as the package name for the target home app.

```
    actualIntent.setPackage(info.resolvePackageName);
```

However, `ResolveInfo#resolvePackageName` does not mean the package name of the target app and is almost always null.
https://developer.android.com/reference/android/content/pm/ResolveInfo#resolvePackageName
As a result, the sent intent becomes an implicit intent because package name is not set. And on Android 8 and later, broadcasting implicit intents is prohibited.
https://developer.android.com/guide/components/broadcasts#android_80

My solution is to get the package name from `ActivityInfo#packageName`.
I have confirmed that DefaultBadger works fine on an Android 9 device with this fix.