### PR TITLE
Update VIVO support

### DIFF
--- a/ShortcutBadger/src/main/AndroidManifest.xml
+++ b/ShortcutBadger/src/main/AndroidManifest.xml
@@ -40,6 +40,9 @@
     <uses-permission android:name="com.oppo.launcher.permission.READ_SETTINGS"/>
     <uses-permission android:name="com.oppo.launcher.permission.WRITE_SETTINGS"/>
 
+    <!--for VIVO-->
+    <uses-permission android:name="com.vivo.notification.permission.BADGE_ICON"/>
+
     <!--for EvMe-->
     <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_READ"/>
     <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_WRITE"/>

--- a/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/VivoHomeBadger.java
+++ b/ShortcutBadger/src/main/java/me/leolin/shortcutbadger/impl/VivoHomeBadger.java
@@ -12,6 +12,7 @@ import me.leolin.shortcutbadger.ShortcutBadgeException;
 
 /**
  * @author leolin
+ * see also https://dev.vivo.com.cn/documentCenter/doc/459.
  */
 public class VivoHomeBadger implements Badger {
 
@@ -21,11 +22,15 @@ public class VivoHomeBadger implements Badger {
         intent.putExtra("packageName", context.getPackageName());
         intent.putExtra("className", componentName.getClassName());
         intent.putExtra("notificationNum", badgeCount);
+        intent.addFlags(0x01000000); // Intent.FLAG_RECEIVER_INCLUDE_BACKGROUND for Android 8.0
         context.sendBroadcast(intent);
     }
 
     @Override
     public List<String> getSupportLaunchers() {
-        return Arrays.asList("com.vivo.launcher");
+        return Arrays.asList(
+            "com.vivo.launcher",
+            "com.bbk.launcher2"
+        );
     }
 }


### PR DESCRIPTION
@leolin310148 
Added the `"com.vivo.notification.permission.BADGE_ICON"` to make the notification settings provide the badge option, otherwise it doesn't work.

Added the `FLAG_RECEIVER_INCLUDE_BACKGROUND` based on VIVO and third-party documents, there is no Android 8.0 devices to truly test.
Added the `"com.bbk.launcher2"` for failback, <s>the package exists, but no truly test.</s> It will resolve the operations failed when the KISS Launcher is installed.

On vivo Z1, Android 9.0.